### PR TITLE
fix: sqid attribute return type

### DIFF
--- a/src/Concerns/HasSqids.php
+++ b/src/Concerns/HasSqids.php
@@ -18,7 +18,7 @@ trait HasSqids
         $this->append(['sqid']);
     }
 
-    public function getSqidAttribute(): ?string
+    public function getSqidAttribute(): string
     {
         return Sqids::forModel(model: $this);
     }


### PR DESCRIPTION
Due to the underlaying implementation, the sqid attribute will never be `null`. This fixes the return type of the method to only return a `string`.