### PR TITLE
sqid attribute should return null if the id attribute is null

### DIFF
--- a/src/Sqids.php
+++ b/src/Sqids.php
@@ -44,9 +44,9 @@ class Sqids
         return $prefixClass->prefix(model: $model);
     }
 
-    public static function encodeId(string $model, int $id): string
+    public static function encodeId(string $model, ?int $id): ?string
     {
-        return static::encoder(model: $model)->encode(numbers: [$id]);
+        return $id !== null ? static::encoder(model: $model)->encode(numbers: [$id]) : null;
     }
 
     /**


### PR DESCRIPTION
#6 

When the id attribute is null (unsaved model), the sqid attribute should also return null and not throw an error.

How to recreate:

$model = new \App\Models\Model();
echo $model->sqid;