### PR TITLE
sqid return null when id is null (new unsaved model)

### DIFF
--- a/src/Concerns/HasSqids.php
+++ b/src/Concerns/HasSqids.php
@@ -18,7 +18,7 @@ trait HasSqids
         $this->append(['sqid']);
     }
 
-    public function getSqidAttribute(): string
+    public function getSqidAttribute(): ?string
     {
         return Sqids::forModel(model: $this);
     }

--- a/src/Sqids.php
+++ b/src/Sqids.php
@@ -10,10 +10,14 @@ use Sqids\Sqids as SqidsCore;
 
 class Sqids
 {
-    public static function forModel(Model $model): string
+    public static function forModel(Model $model): ?string
     {
         /** @var int $id */
         $id = $model->getKey();
+
+        if ($id === null) {
+            return null;
+        }
 
         $prefix = static::prefixForModel(model: $model::class);
         $separator = $prefix ? Config::separator() : null;

--- a/src/Sqids.php
+++ b/src/Sqids.php
@@ -12,7 +12,7 @@ class Sqids
 {
     public static function forModel(Model $model): ?string
     {
-        /** @var int $id */
+        /** @var int|null $id */
         $id = $model->getKey();
 
         if ($id === null) {


### PR DESCRIPTION
#6 

When the id attribute is null (unsaved model), the sqid attribute should return null also and not throw an error.

How to recreate:

$model = new \App\Models\Model();
echo $model->said;

(Sorry for the back and forth, I'm not the best with pull requests)