### PR TITLE
Fix scoped route model binding

### DIFF
--- a/src/Concerns/HasSqids.php
+++ b/src/Concerns/HasSqids.php
@@ -53,7 +53,7 @@ trait HasSqids
             return parent::resolveRouteBindingQuery(query: $query, value: $value, field: $field);
         }
 
-        return $this->whereSqid(sqid: $value);
+        return $query->whereSqid(sqid: $value);
     }
 
     public static function keyFromSqid(string $sqid): ?int

--- a/tests/RouteModelBindingTest.php
+++ b/tests/RouteModelBindingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Workbench\Database\Factories\ChargeFactory;
 use Workbench\Database\Factories\CustomerFactory;
 use Workbench\Database\Factories\PostFactory;
 
@@ -43,4 +44,22 @@ it('can bind a model when the route key has been overridden', function (): void 
     $this
         ->get(uri: "/posts/{$post->slug}")
         ->assertContent(value: $post->title);
+});
+
+it('can scope route model bindings', function (): void {
+    $customer = CustomerFactory::new()->create();
+    $charge = ChargeFactory::new()->for($customer)->create();
+
+    $this
+        ->get(uri: "/customers/{$customer->sqid}/{$charge->sqid}")
+        ->assertContent(value: $charge->sqid);
+});
+
+it('returns a 404 if the child isn’t scoped to the parent', function (): void {
+    $customer = CustomerFactory::new()->create();
+    $charge = ChargeFactory::new()->create();
+
+    $this
+        ->get(uri: "/customers/{$customer->sqid}/{$charge->sqid}")
+        ->assertNotFound();
 });

--- a/workbench/app/Models/Charge.php
+++ b/workbench/app/Models/Charge.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use RedExplosion\Sqids\Concerns\HasSqids;
 
 class Charge extends Model
@@ -12,4 +13,12 @@ class Charge extends Model
     use HasSqids;
 
     protected string $sqidPrefix = 'ch';
+
+    /**
+     * @return BelongsTo<Customer,$this>
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
 }

--- a/workbench/app/Models/Customer.php
+++ b/workbench/app/Models/Customer.php
@@ -5,9 +5,18 @@ declare(strict_types=1);
 namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use RedExplosion\Sqids\Concerns\HasSqids;
 
 class Customer extends Model
 {
     use HasSqids;
+
+    /**
+     * @return HasMany<Charge,$this>
+     */
+    public function charges(): HasMany
+    {
+        return $this->hasMany(Charge::class);
+    }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Workbench\App\Models\Charge;
 use Workbench\App\Models\Customer;
 use Workbench\App\Models\Post;
 
 Route::get(uri: 'customers/username/{customer:username}', action: fn (Customer $customer) => $customer->username);
 Route::get(uri: 'customers/{customer}', action: fn (Customer $customer) => $customer->name);
+Route::get(uri: 'customers/{customer}/{charge}', action: fn (Customer $customer, Charge $charge) => $charge->sqid)->scopeBindings();
 
 Route::get(uri: 'posts/{post}', action: fn (Post $post) => $post->title);


### PR DESCRIPTION
When using [scoped route model binding](https://laravel.com/docs/12.x/routing#implicit-model-binding-scoping) with a child model that uses a SQID as its route key, the child model is not properly scoped to the parent. 

```php
Route::get('/customers/{customer}/{charge}')->scopeBindings();
```

When applying the `->whereSqid()` condition, the `HasSqids` trait currently re-instantiates a query from the trait's parent `Model` instance rather than chaining onto the provided `$query` parameter, which would contain and instance of the parent's scoped relationship.

```php
// HasSqids.php
public function resolveRouteBindingQuery($query, $value, $field = null): Builder|Relation 
{
    // ...

    // Current behavior
    return $this->whereSqid(sqid: $value); // Equivalent to Charge::query()->whereSqid(sqid: $value);

    // Proposed behavior
    return $query->whereSqid(sqid: $value); // Equivalent to $customer->charges->whereSqid(sqid: $value);
}
```