### PR TITLE
Bump to sqids ^0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "sqids/sqids": "^0.4.1"
+        "sqids/sqids": "^0.5"
     },
     "require-dev": {
         "laravel/pint": "^1.10",


### PR DESCRIPTION
composer update won't get sqids 0.5 because it is currently still below 1.0

so manually bumping it in composer.json